### PR TITLE
Add map section to About page

### DIFF
--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,8 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps =
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/AboutPage.tsx
+++ b/src/pages/AboutPage.tsx
@@ -153,6 +153,23 @@ const AboutPage = () => {
               </div>
             </div>
           </div>
+
+          {/* Map Section */}
+          <div className="mb-12">
+            <h2 className="text-2xl font-semibold mb-4">Find Us</h2>
+            <div className="w-full h-64">
+              <iframe
+                title="shop-location"
+                src="https://www.google.com/maps?q=Suncity+Road,+Kengeri,+Bengaluru,+Karnataka,+India&output=embed"
+                width="100%"
+                height="100%"
+                loading="lazy"
+                allowFullScreen
+                referrerPolicy="no-referrer-when-downgrade"
+                className="w-full h-full border-0"
+              />
+            </div>
+          </div>
         </div>
       </div>
     </MainLayout>

--- a/src/pages/ProductsPage.tsx
+++ b/src/pages/ProductsPage.tsx
@@ -63,8 +63,10 @@ const ProductsPage = () => {
     setPriceRange([value[0], value[1]]);
   };
 
-  const handleSortChange = (value: string) => {
-    setSortBy(value as any);
+  const handleSortChange = (
+    value: "featured" | "priceAsc" | "priceDesc" | "nameAsc" | "nameDesc" | "rating"
+  ) => {
+    setSortBy(value);
   };
 
   const applyFilters = (

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import animate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -127,5 +128,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [animate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- embed Google map in About page
- convert empty interfaces to type aliases
- type sort change handler properly
- use ES module import for Tailwind plugin

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68835d1fa4348330ac9131a4df7f223b